### PR TITLE
Fixed progress bar print flushing too much

### DIFF
--- a/pySmartDL/pySmartDL.py
+++ b/pySmartDL/pySmartDL.py
@@ -623,7 +623,7 @@ class ControlThread(threading.Thread):
                 else:
                     status = r"[*] %s / ??? MB @ %s/s   " % (utils.sizeof_human(self.shared_var.value), utils.sizeof_human(self.dl_speed))
                 status = status + chr(8)*(len(status)+1)
-                print(status, end='', flush=True)
+                print(status, end=' ', flush=True)
             time.sleep(0.1)
             
         if self.obj._killed:


### PR DESCRIPTION
Changed printing of progress bar to end with a space to prevent print from flushing the whole terminal buffer; one character per update.
issue: ![issue](https://media.giphy.com/media/l3gCmUfzWnG8rbBkqP/giphy.gif)