### PR TITLE
Allow passing of custom arguments to urllib Request object

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -46,8 +46,22 @@ Example 3: Mirrors are also supported
 
 	# Do something with obj.get_dest()
 
+=============================================================
+Example 4: Passing custom options to urllib.request.Request()
+=============================================================
+::
+
+	from pySmartDL import SmartDL
+
+	request_args = {"headers": {"User-Agent": "smyPartDL/86.75.309"}}
+	download_obj = SmartDL("http://httpbin.org/get", "./headerinfo.json", request_args=request_args)
+	download_obj.start()
+
+	# headerinfo.json should contain the custom headers
+
+
 ==================================================================
-Example 4: Fetch data to memory instead of reading it from a file
+Example 5: Fetch data to memory instead of reading it from a file
 ==================================================================
 ::
 
@@ -62,7 +76,7 @@ Example 4: Fetch data to memory instead of reading it from a file
 	# Do something with data
 	
 ====================================================================================
-Example 5: Use the nonblocking flag and get information during the download process
+Example 6: Use the nonblocking flag and get information during the download process
 ====================================================================================
 ::
 
@@ -98,7 +112,7 @@ Example 5: Use the nonblocking flag and get information during the download proc
 	# Do something with obj.get_dest()
 	
 =========================
-Example 6: Hash checking
+Example 7: Hash checking
 =========================
 
 Example with passing `blocking=True` to `obj.start()`::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@ Python Smart Download Manager -- pySmartDL
 * Speed limiting feature.
 * Hash checking.
 * Non-blocking, shows progress bar, download speed and eta.
-* Full support for proxies, custom headers, and more
+* Full support for custom headers and methods
 * Python 3 Support
 
 =============

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@
 Python Smart Download Manager -- pySmartDL
 ==========================================
 
-``pySmartDL`` strives to be a full-pledged smart download manager for Python. Main features:
+``pySmartDL`` strives to be a full-fledged smart download manager for Python. Main features:
 
 * Built-in download acceleration (with the `multipart downloading technique <http://stackoverflow.com/questions/93642/how-do-download-accelerators-work>`_).
 * Mirrors support.
@@ -14,6 +14,7 @@ Python Smart Download Manager -- pySmartDL
 * Speed limiting feature.
 * Hash checking.
 * Non-blocking, shows progress bar, download speed and eta.
+* Full support for proxies, custom headers, and more
 * Python 3 Support
 
 =============

--- a/pySmartDL/download.py
+++ b/pySmartDL/download.py
@@ -4,7 +4,7 @@ import time
 
 from . import utils
 
-def download(url, dest, requestArgs, startByte=0, endByte=None, timeout=4, shared_var=None, thread_shared_cmds=None, logger=None, retries=3):
+def download(url, dest, requestArgs=None, startByte=0, endByte=None, timeout=4, shared_var=None, thread_shared_cmds=None, logger=None, retries=3):
     "The basic download function that runs at each thread."
     logger = logger or utils.DummyLogger()
     req = urllib.request.Request(url, **requestArgs)

--- a/pySmartDL/pySmartDL.py
+++ b/pySmartDL/pySmartDL.py
@@ -49,7 +49,7 @@ class SmartDL:
     The main SmartDL class
     
     :param urls: Download url. It is possible to pass unsafe and unicode characters. You can also pass a list of urls, and those will be used as mirrors.
-    :type urls: string or list of string
+    :type urls: string or list of strings
     :param requestArgs: Arguments to be passed to a new urllib.request.Request instance in dictionary form. See https://docs.python.org/3/library/urllib.request.html#urllib.request.Request for options. 
     :type requestArgs: dict
     :param dest: Destination path. Default is `%TEMP%/pySmartDL/`.

--- a/pySmartDL/pySmartDL.py
+++ b/pySmartDL/pySmartDL.py
@@ -50,8 +50,6 @@ class SmartDL:
     
     :param urls: Download url. It is possible to pass unsafe and unicode characters. You can also pass a list of urls, and those will be used as mirrors.
     :type urls: string or list of strings
-    :param requestArgs: Arguments to be passed to a new urllib.request.Request instance in dictionary form. See https://docs.python.org/3/library/urllib.request.html#urllib.request.Request for options. 
-    :type requestArgs: dict
     :param dest: Destination path. Default is `%TEMP%/pySmartDL/`.
     :type dest: string
     :param progress_bar: If True, prints a progress bar to the `stdout stream <http://docs.python.org/2/library/sys.html#sys.stdout>`_. Default is `True`.
@@ -66,6 +64,8 @@ class SmartDL:
     :type logger: `logging.Logger` instance
     :param connect_default_logger: If true, connects a default logger to the class.
     :type connect_default_logger: bool
+    :param requestArgs: Arguments to be passed to a new urllib.request.Request instance in dictionary form. See https://docs.python.org/3/library/urllib.request.html#urllib.request.Request for options. 
+    :type requestArgs: dict
     :rtype: `SmartDL` instance
     
     .. NOTE::

--- a/pySmartDL/pySmartDL.py
+++ b/pySmartDL/pySmartDL.py
@@ -158,7 +158,7 @@ class SmartDL:
         '''
         auth_string = '%s:%s' % (username, password)
         base64string = base64.standard_b64encode(auth_string.encode('utf-8'))
-        self.headers['Authorization'] = b"Basic " + base64string
+        self.requestArgs['headers']['Authorization'] = b"Basic " + base64string
         
     def add_hash_verification(self, algorithm, hash):
         '''

--- a/pySmartDL/pySmartDL.py
+++ b/pySmartDL/pySmartDL.py
@@ -85,6 +85,8 @@ class SmartDL:
         else:
             self.logger = utils.DummyLogger()
         if requestArgs:
+            if "headers" not in requestArgs:
+                requestArgs["headers"] = dict()
             self.requestArgs = requestArgs
         else:
             self.requestArgs = {"headers": dict()}

--- a/pySmartDL/pySmartDL.py
+++ b/pySmartDL/pySmartDL.py
@@ -77,17 +77,17 @@ class SmartDL:
             * If no path is provided, `%TEMP%/pySmartDL/` will be used.
     '''
     
-    def __init__(self, urls, dest=None, progress_bar=True, fix_urls=True, threads=5, timeout=5, logger=None, connect_default_logger=False, requestArgs=None):
+    def __init__(self, urls, dest=None, progress_bar=True, fix_urls=True, threads=5, timeout=5, logger=None, connect_default_logger=False, request_args=None):
         if logger:
             self.logger = logger
         elif connect_default_logger:
             self.logger = utils.create_debugging_logger()
         else:
             self.logger = utils.DummyLogger()
-        if requestArgs:
-            if "headers" not in requestArgs:
-                requestArgs["headers"] = dict()
-            self.requestArgs = requestArgs
+        if request_args:
+            if "headers" not in request_args:
+                request_args["headers"] = dict()
+            self.requestArgs = request_args
         else:
             self.requestArgs = {"headers": dict()}
         if "User-Agent" not in self.requestArgs["headers"]:


### PR DESCRIPTION
This will allow for more granular control of headers, proxies, and anything else that urllib provides an option for without having to implement the functionality in pySmartDL. Closes #33