### PR TITLE
Allow dest to refer to a filename relative to working directory

### DIFF
--- a/pySmartDL/pySmartDL.py
+++ b/pySmartDL/pySmartDL.py
@@ -130,17 +130,18 @@ class SmartDL:
         self.post_threadpool_thread = None
         self.control_thread = None
         
-        if not os.path.exists(os.path.dirname(self.dest)):
-            self.logger.info('Folder "{}" does not exist. Creating...'.format(os.path.dirname(self.dest)))
-            os.makedirs(os.path.dirname(self.dest))
+        dir = os.path.dirname(self.dest)
+        if not dir:
+            self.dest = os.path.join(".", self.dest)
+        else:
+            if not os.path.exists(dir):
+                self.logger.info('Directory "{}" does not exist. Creating it...'.format(dir))
+                os.makedirs(dir)
         if not utils.is_HTTPRange_supported(self.url, timeout=self.timeout):
             self.logger.warning("Server does not support HTTPRange. threads_count is set to 1.")
             self.threads_count = 1
         if os.path.exists(self.dest):
             self.logger.warning('Destination "{}" already exists. Existing file will be removed.'.format(self.dest))
-        if not os.path.exists(os.path.dirname(self.dest)):
-            self.logger.warning('Directory "{}" does not exist. Creating it...'.format(os.path.dirname(self.dest)))
-            os.makedirs(os.path.dirname(self.dest))
         
         self.logger.info("Creating a ThreadPool of {} thread(s).".format(self.threads_count))
         self.pool = utils.ManagedThreadPoolExecutor(self.threads_count)

--- a/pySmartDL/pySmartDL.py
+++ b/pySmartDL/pySmartDL.py
@@ -132,6 +132,7 @@ class SmartDL:
         
         dir = os.path.dirname(self.dest)
         if not dir:
+            self.logger.info('Destination "{}" does not have a directory component. Placing it in current working directory'.format(self.dest))
             self.dest = os.path.join(".", self.dest)
         else:
             if not os.path.exists(dir):


### PR DESCRIPTION
1) Allows user to set dest as merely a filename to be placed in the current directory

If self.dest is set, but lacks a directory portion, then sets self.dest to itself with the working directory ['.'+os.sep] appended to the front of it.

2) Made so only checks for / creates the output directory once.

Note:
Without the change, if the the dest was a simply specified as a filename, the calls to `os.makedirs(os.path.dirname(self.dest))` failed, because `os.path.dirname(self.dest)` evaluated to ''